### PR TITLE
Composer support for Console_Table

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "library",
     "description": "Class that makes it easy to build console style tables.",
     "keywords": [ "console" ],
-    "homepage": "http://pear.php.net/package/Console_Table/",
+    "homepage": "https://github.com/pear/Console_Table",
     "license": "BSD",
     "authors": [
         {


### PR DESCRIPTION
Along with adding [Composer support to Console_Color2](https://github.com/pear/Console_Color2/pull/2), we should add Composer support to Console_Table. It still uses Console_Color 1, so I left the suggest for Console_Color 1 in there until we update the examples to 2.
