### PR TITLE
Table output inserts bogus \r character when not on Windows

### DIFF
--- a/Table.php
+++ b/Table.php
@@ -609,7 +609,12 @@ class Console_Table
             $return .= "\r\n";
         }
         if (!empty($this->_headers)) {
+          if (!stristr(PHP_OS, 'WIN')) {
             $return = $this->_getHeaderLine() .  "\r\n" . $return;
+          }
+          else {
+            $return = $this->_getHeaderLine() .  "\n" . $return;
+          }
         }
 
         return $return;


### PR DESCRIPTION
Hi, I would greatly like to have this patch applied to Table.php.

This patch fixes an issue with another project on github drush-ops/drush#192.

I use Drush to make reports on OS X and those reports right now have ^M, which are useless outside of Windows.

Let me know if I can provide more information.
