### PR TITLE
Composer: Use lower case for the package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pear/Console_Table",
+    "name": "pear/console_table",
     "type": "library",
     "description": "Class that makes it easy to build console style tables.",
     "keywords": [ "console" ],


### PR DESCRIPTION
Composer requires the use of lower case package names.
