### PR TITLE
Fix suggest to require of console/color2

### DIFF
--- a/Table.php
+++ b/Table.php
@@ -199,7 +199,6 @@ class Console_Table
         $this->setBorder($border);
         $this->_padding      = $padding;
         if ($color) {
-            include_once 'Console/Color2.php';
             $this->_ansiColor = new Console_Color2();
         }
         if (!empty($charset)) {

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,7 @@
         }
     ],
     "require": {
-        "php": ">=4.3.10"
-    },
-    "suggest": {
+        "php": ">=4.3.10",
         "pear/Console_Color2": ">=0.1.2"
     },
     "autoload": {


### PR DESCRIPTION
It's not logical to do an include once of Console/Color2.php
If you have both classes using composer, this won't work because you won't have them using pear.
It's better not to have them in Pear and use both classes using composer
