### PR TITLE
Fix issues for users using the pear/console_color2 composer package

### DIFF
--- a/Table.php
+++ b/Table.php
@@ -199,7 +199,7 @@ class Console_Table
         $this->setBorder($border);
         $this->_padding      = $padding;
         if ($color) {
-            if(!class_exists(Console_Color2)) {
+            if (!class_exists(Console_Color2)) {
                 include_once 'Console/Color2.php';
             }
             $this->_ansiColor = new Console_Color2();


### PR DESCRIPTION
When using the pear/console_color2 composer package the include_once will fail.
This solution will continue to work for people using the pear version of Console/Color2
