### PR TITLE
Old style constructors are deprecated in PHP 7

### DIFF
--- a/Table.php
+++ b/Table.php
@@ -2,7 +2,7 @@
 /**
  * Utility for printing tables from commandline scripts.
  *
- * PHP versions 4 and 5
+ * PHP versions 5 and 7
  *
  * All rights reserved.
  *
@@ -191,9 +191,9 @@ class Console_Table
      *                         extension.
      * @param boolean $color   Whether the data contains ansi color codes.
      */
-    function Console_Table($align = CONSOLE_TABLE_ALIGN_LEFT,
-                           $border = CONSOLE_TABLE_BORDER_ASCII, $padding = 1,
-                           $charset = null, $color = false)
+    function __construct($align = CONSOLE_TABLE_ALIGN_LEFT,
+                         $border = CONSOLE_TABLE_BORDER_ASCII, $padding = 1,
+                         $charset = null, $color = false)
     {
         $this->_defaultAlign = $align;
         $this->setBorder($border);

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": ">=4.3.10"
+        "php": ">=5.2.0"
     },
     "suggest": {
         "pear/Console_Color2": ">=0.1.2"

--- a/package.xml
+++ b/package.xml
@@ -65,7 +65,7 @@
  <dependencies>
   <required>
    <php>
-    <min>4.3.10</min>
+    <min>5.2.0</min>
    </php>
    <pearinstaller>
     <min>1.4.0b1</min>


### PR DESCRIPTION
When using Console_Table on PHP 7 the following notice appears:

> Methods with the same name as their class will not be constructors in a future version of PHP; Console_Table has a deprecated constructor in Table.php on line 58

This means we have to drop support for PHP 4, but this is long obsolete. I checked and saw that other PEAR packages are also requiring 5.1.2 or higher now.