### PR TITLE
fromArray is static

### DIFF
--- a/Table.php
+++ b/Table.php
@@ -223,7 +223,7 @@ class Console_Table
      * @return Console_Table|string  A Console_Table object or the generated
      *                               table.
      */
-    function fromArray($headers, $data, $returnObject = false)
+    static function fromArray($headers, $data, $returnObject = false)
     {
         if (!is_array($headers) || !is_array($data)) {
             return false;


### PR DESCRIPTION
As stated in the doc block

Also this fix test failure with PHP 8

`016+ Fatal error: Uncaught Error: Non-static method Console_Table::fromArray() cannot be called statically in /builddir/build/BUILD/php-pear-Console-Table-1.3.1/Console_Table-1.3.1/tests/multiline.php:22`